### PR TITLE
fix: persist join notice, pin DMs to latest, and clear unread badges

### DIFF
--- a/frontend/src/api/messagingSocket.ts
+++ b/frontend/src/api/messagingSocket.ts
@@ -4,7 +4,7 @@
  * 服务端未就绪时连接失败不影响页面——评论 / 私信 / 通知仍走 HTTP。
  */
 
-export type MessagingPushKind = "dm" | "notification" | "comment";
+export type MessagingPushKind = "dm" | "notification" | "comment" | "unread";
 
 export interface MessagingPushEvent {
   event: MessagingPushKind;
@@ -34,7 +34,7 @@ function parseEvent(raw: string): MessagingPushEvent | null {
   try {
     const data = JSON.parse(raw);
     const event = data?.event ?? data?.type;
-    if (event !== "dm" && event !== "notification" && event !== "comment") return null;
+    if (event !== "dm" && event !== "notification" && event !== "comment" && event !== "unread") return null;
     const payload = data?.payload && typeof data.payload === "object" && !Array.isArray(data.payload)
       ? data.payload
       : data;
@@ -140,4 +140,9 @@ export function onMessagingOpen(fn: () => void): Unsub {
 export function onMessagingEvent(fn: (ev: MessagingPushEvent) => void): Unsub {
   eventListeners.add(fn);
   return () => { eventListeners.delete(fn); };
+}
+
+/** 本地发出与 WS 同形的事件（如 mark_read 完成后刷新未读徽标）。 */
+export function emitMessagingEvent(ev: MessagingPushEvent) {
+  eventListeners.forEach((fn) => fn(ev));
 }

--- a/frontend/src/api/recruitment.ts
+++ b/frontend/src/api/recruitment.ts
@@ -12,7 +12,7 @@ export interface RecruitmentLanding {
 export const recruitmentApi = {
   landing: () => request("/") as Promise<RecruitmentLanding>,
   updateNotice: (content: string) =>
-    request("/notice/", { method: "PUT", body: JSON.stringify({ content }) }),
+    request("/notice/", { method: "PUT", body: JSON.stringify({ content }) }) as Promise<{ content: string; updated_at: string }>,
   getSchema: () => request("/schema/") as Promise<{ schema: Record<string, unknown>; updated_at: string }>,
   updateSchema: (schema: Record<string, unknown>) =>
     request("/schema/", { method: "PUT", body: JSON.stringify({ schema }) }),

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -143,7 +143,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
     };
     const offOpen = onMessagingOpen(refreshBadges);
     const offEv = onMessagingEvent((ev) => {
-      if (ev.event === "dm") {
+      if (ev.event === "dm" || ev.event === "unread") {
         messagingApi.unreadCount().then((d) => setDmCount(Number(d?.total) || 0)).catch(() => {});
       }
       if (ev.event === "notification") {

--- a/frontend/src/components/MessageThread.tsx
+++ b/frontend/src/components/MessageThread.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { messagingApi } from "../api/messaging";
-import { onMessagingEvent, onMessagingOpen } from "../api/messagingSocket";
+import { emitMessagingEvent, onMessagingEvent, onMessagingOpen } from "../api/messagingSocket";
 import type { DirectMessage } from "../types/messaging";
 import { withinRetractWindow } from "../types/messaging";
 import type { TaskUser } from "../types/tasks";
@@ -36,6 +36,7 @@ export default function MessageThread({
   const [now, setNow] = useState(Date.now());
   const listRef = useRef<HTMLDivElement>(null);
   const countRef = useRef(0);
+  const pinToBottom = useRef(true);
 
   const mergeLatest = (latest: DirectMessage[]) => {
     const chronological = [...latest].reverse();
@@ -49,8 +50,20 @@ export default function MessageThread({
     });
   };
 
+  const markRead = () =>
+    messagingApi.markRead(conversationId).then(() => {
+      emitMessagingEvent({ event: "unread", payload: { conversation_id: conversationId } });
+    }).catch(() => {});
+
+  useLayoutEffect(() => {
+    if (!autoScroll || loading || !pinToBottom.current) return;
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, loading, autoScroll]);
+
   useEffect(() => {
     let cancelled = false;
+    pinToBottom.current = true;
     setLoading(true);
     setMessages([]);
     setPage(1);
@@ -63,11 +76,10 @@ export default function MessageThread({
         setHasMore(d.next != null);
         countRef.current = d.count;
         onCountChange?.(d.count);
-        if (autoScroll) listRef.current?.scrollTo({ top: listRef.current.scrollHeight });
       })
       .catch(console.error)
       .finally(() => { if (!cancelled) setLoading(false); });
-    messagingApi.markRead(conversationId).catch(() => {});
+    markRead();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
@@ -87,13 +99,15 @@ export default function MessageThread({
         mergeLatest(d.results);
         countRef.current = d.count;
         onCountChange?.(d.count);
-        if (autoScroll) listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
       }).catch(() => {});
     };
     const offOpen = onMessagingOpen(pull);
     const offEv = onMessagingEvent((ev) => {
       if (ev.event !== "dm") return;
-      if (Number(ev.payload?.conversation_id) === conversationId) pull();
+      if (Number(ev.payload?.conversation_id) === conversationId) {
+        pull();
+        markRead();
+      }
     });
     return () => { offOpen(); offEv(); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -102,6 +116,7 @@ export default function MessageThread({
   const loadEarlier = async () => {
     if (loadingMore) return;
     setLoadingMore(true);
+    pinToBottom.current = false;
     const next = page + 1;
     const prevHeight = listRef.current?.scrollHeight ?? 0;
     try {
@@ -126,11 +141,11 @@ export default function MessageThread({
     setError("");
     try {
       const m = await messagingApi.sendMessage(conversationId, input.trim());
+      pinToBottom.current = true;
       setMessages((prev) => [...prev, m]);
       setInput("");
       countRef.current += 1;
       onCountChange?.(countRef.current);
-      if (autoScroll) listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
     } catch (err: any) {
       setError(err?.message || "发送失败");
     } finally {
@@ -150,7 +165,15 @@ export default function MessageThread({
 
   return (
     <>
-      <div className="msg-bubbles" ref={listRef}>
+      <div
+        className="msg-bubbles"
+        ref={listRef}
+        onScroll={() => {
+          const el = listRef.current;
+          if (!el) return;
+          pinToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+        }}
+      >
         {loading ? (
           <div className="msg-empty">加载中…</div>
         ) : (

--- a/frontend/src/components/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor.tsx
@@ -203,7 +203,10 @@ export default function RichTextEditor({
     ],
     content,
     editable,
-    onCreate: ({ editor }) => onStatsRef.current?.(editor.getText().length),
+    onCreate: ({ editor }) => {
+      onChangeRef.current?.(editor.getHTML());
+      onStatsRef.current?.(editor.getText().length);
+    },
     onUpdate: ({ editor }) => {
       onChangeRef.current?.(editor.getHTML());
       onStatsRef.current?.(editor.getText().length);

--- a/frontend/src/pages/JoinPage.tsx
+++ b/frontend/src/pages/JoinPage.tsx
@@ -17,24 +17,40 @@ export default function JoinPage() {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+  const [rteKey, setRteKey] = useState(0);
+
+  const applyNotice = (html: string) => {
+    setContent(html);
+    setDraft(html);
+  };
 
   useEffect(() => {
     document.title = "加入社团 · 南汇一中传媒社";
-    recruitmentApi.landing().then((d) => {
-      setContent(d.notice.content || "");
-      setDraft(d.notice.content || "");
-    });
+    recruitmentApi.landing()
+      .then((d) => applyNotice(d.notice.content || ""))
+      .catch(() => {});
     api.me()
       .then((d: any) => setCanEdit(!!d.user?.permissions?.can_edit_about))
       .catch(() => setCanEdit(false));
   }, []);
 
+  const startEdit = () => {
+    setDraft(content);
+    setSaveError("");
+    setRteKey((k) => k + 1);
+    setEditing(true);
+  };
+
   const save = async () => {
     setSaving(true);
+    setSaveError("");
     try {
-      await recruitmentApi.updateNotice(draft);
-      setContent(draft);
+      const saved = await recruitmentApi.updateNotice(draft);
+      applyNotice(saved.content || draft);
       setEditing(false);
+    } catch (e: any) {
+      setSaveError(e?.message || "保存失败");
     } finally {
       setSaving(false);
     }
@@ -54,7 +70,7 @@ export default function JoinPage() {
             {canEdit && !editing && (
               <div style={{ display: "flex", gap: 8 }}>
                 <button className="btn btn-ghost btn-sm" onClick={() => navigate("/join/editor")}>编辑问卷</button>
-                <button className="btn btn-ghost btn-sm" onClick={() => setEditing(true)}>编辑公告</button>
+                <button className="btn btn-ghost btn-sm" type="button" onClick={startEdit}>编辑公告</button>
               </div>
             )}
           </div>
@@ -72,15 +88,16 @@ export default function JoinPage() {
           ) : (
             <>
               <RichTextEditor
-                key="e"
+                key={`e-${rteKey}`}
                 content={draft}
                 onChange={setDraft}
                 imageUpload={(f: File) => newsApi.uploadImage(f).then((d) => d.url)}
                 minHeight={280}
               />
+              {saveError && <div className="alert alert-danger" style={{ marginTop: 12 }}>{saveError}</div>}
               <div className="form-actions" style={{ marginTop: 12 }}>
-                <button className="btn btn-ghost" onClick={() => setEditing(false)}>取消</button>
-                <button className="btn btn-primary" disabled={saving} onClick={save}>保存</button>
+                <button className="btn btn-ghost" type="button" onClick={() => { setEditing(false); setSaveError(""); }}>取消</button>
+                <button className="btn btn-primary" type="button" disabled={saving} onClick={save}>{saving ? "保存中…" : "保存"}</button>
               </div>
             </>
           )}

--- a/frontend/src/pages/MessagePage.tsx
+++ b/frontend/src/pages/MessagePage.tsx
@@ -69,7 +69,7 @@ export default function MessagePage() {
     };
     const offOpen = onMessagingOpen(refresh);
     const offEv = onMessagingEvent((ev) => {
-      if (ev.event === "dm") refresh();
+      if (ev.event === "dm" || ev.event === "unread") refresh();
     });
     return () => { offOpen(); offEv(); };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/SurveyCreatorPage.tsx
+++ b/frontend/src/pages/SurveyCreatorPage.tsx
@@ -45,6 +45,21 @@ export default function SurveyCreatorPage({
         if (!alive) return;
         const c = new SurveyCreator({ showLogicTab: true, locale: SURVEY_LOCALE });
         c.JSON = schema || EMPTY_SCHEMA;
+        // Creator 工具栏「保存」默认只提示本地已保存；接到后端才算真正落库。
+        c.saveSurveyFunc = (saveNo: number, callback: (no: number, success: boolean) => void) => {
+          saveRef.current(c.JSON as Record<string, unknown>)
+            .then(() => {
+              if (!alive) return;
+              setMsg("已保存");
+              setError("");
+              callback(saveNo, true);
+            })
+            .catch((err: unknown) => {
+              if (!alive) return;
+              setError(err instanceof Error ? err.message : "保存失败");
+              callback(saveNo, false);
+            });
+        };
         setCreator(c);
       })
       .catch((e: unknown) => {

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -55,6 +55,14 @@ class UnreadCountTest(TestCase):
         MessageReadStatus.objects.create(message=msg, user=self.alice)
         self.assertEqual(self._total(), 0)
 
+    def test_mark_read_clears_unread_via_http(self):
+        Message.objects.create(conversation=self.conv, sender=self.bob, content="在吗")
+        Message.objects.create(conversation=self.conv, sender=self.bob, content="还有个事")
+        self.assertEqual(self._total(), 2)
+        resp = self.client.post(f"/messaging/conversations/{self.conv.pk}/mark_read/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(self._total(), 0)
+
     def test_only_counts_conversations_user_joined(self):
         # alice 不参与的会话里的消息，不计入 alice 的未读
         carol = User.objects.create_user(username="carol", password="secret123")

--- a/recruitment/tests.py
+++ b/recruitment/tests.py
@@ -90,6 +90,7 @@ class SchemaPersistTest(TestCase):
         resp = client.put("/recruitment/notice/", {"content": "<p>2026 招生</p>"}, format="json")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(RecruitmentNotice.objects.get_solo().content, "<p>2026 招生</p>")
+        self.assertEqual(resp.data["content"], "<p>2026 招生</p>")
 
     def test_invalid_schema_rejected(self):
         client = APIClient()


### PR DESCRIPTION
## Summary
- Join-club announcement save now writes through to `PUT /recruitment/notice/`, remounts the editor from the stored HTML, and surfaces errors instead of claiming success on a stale empty draft. Survey creator toolbar Save also persists to the backend.
- DM threads pin to the latest message after render (and stay there on send/receive unless you scroll up to load history).
- Opening a thread marks messages read and refreshes the nav badge plus conversation-list unread state.

## Test plan
- [ ] Edit and save the 加入社团 notice; reopen the editor and confirm the saved HTML is there.
- [ ] Open a long DM thread and land on the latest message.
- [ ] Open an unread conversation and confirm the red dot clears on the nav and in the list.